### PR TITLE
Add cursor style shader uniform

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2362,6 +2362,16 @@ keybind: Keybinds = .{},
 ///    the same time as the `iTime` uniform, allowing you to compute the
 ///    time since the change by subtracting this from `iTime`.
 ///
+///  * `int iCursorStyle` - Style of the terminal cursor.
+///
+///    Integer value representing the current cursor style:
+///    - `0` = block cursor
+///    - `1` = hollow block cursor  
+///    - `2` = bar cursor
+///    - `3` = underline cursor
+///    - `4` = lock cursor (used in password input)
+///    - `-1` = no cursor (cursor is hidden)
+///
 /// If the shader fails to compile, the shader will be ignored. Any errors
 /// related to shader compilation will not show up as configuration errors
 /// and only show up in the log, since shader compilation happens after

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -159,6 +159,9 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
         /// Custom shader uniform values.
         custom_shader_uniforms: shadertoy.Uniforms,
 
+        /// Current cursor style for use in custom shader uniforms.
+        current_cursor_style: ?renderer.CursorStyle = null,
+
         /// Timestamp we rendered out first frame.
         ///
         /// This is used when updating custom shader uniforms.
@@ -2268,6 +2271,19 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     uniforms.cursor_change_time = uniforms.time;
                 }
             }
+
+            // Update cursor style uniform
+            // Convert cursor style enum to integer values for the shader
+            // 0 = block, 1 = block_hollow, 2 = bar, 3 = underline, 4 = lock, -1 = no cursor
+            self.custom_shader_uniforms.cursor_style = if (self.current_cursor_style) |style| 
+                switch (style) {
+                    .block => 0,
+                    .block_hollow => 1,
+                    .bar => 2,
+                    .underline => 3,
+                    .lock => 4,
+                }
+            else -1;
         }
 
         /// Convert the terminal state to GPU cells stored in CPU memory. These
@@ -2285,6 +2301,9 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
         ) !void {
             self.draw_mutex.lock();
             defer self.draw_mutex.unlock();
+
+            // Store cursor style for use in custom shader uniforms
+            self.current_cursor_style = cursor_style_;
 
             // const start = try std.time.Instant.now();
             // const start_micro = std.time.microTimestamp();

--- a/src/renderer/shaders/shadertoy_prefix.glsl
+++ b/src/renderer/shaders/shadertoy_prefix.glsl
@@ -16,6 +16,7 @@ layout(binding = 1, std140) uniform Globals {
     uniform vec4  iCurrentCursorColor;
     uniform vec4  iPreviousCursorColor;
     uniform float iTimeCursorChange;
+    uniform int   iCursorStyle;
 };
 
 layout(binding = 0) uniform sampler2D iChannel0;

--- a/src/renderer/shadertoy.zig
+++ b/src/renderer/shadertoy.zig
@@ -26,6 +26,7 @@ pub const Uniforms = extern struct {
     current_cursor_color: [4]f32 align(16),
     previous_cursor_color: [4]f32 align(16),
     cursor_change_time: f32 align(4),
+    cursor_style: i32 align(4),
 };
 
 /// The target to load shaders for.


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add `iCursorStyle` uniform to custom shaders to allow them to react to the current cursor style.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->

---
<a href="https://cursor.com/background-agent?bcId=bc-4fd65cd5-2c2f-4e7e-bcbc-8673c4abad9c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4fd65cd5-2c2f-4e7e-bcbc-8673c4abad9c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>